### PR TITLE
Sync development to main

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/install/roles/sslcerts/tasks/main.yml
+++ b/install/roles/sslcerts/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
 # set fact for ansible_hostname
-- set_fact:
-    www_hostname: "{{ansible_hostname}}"
+- name: Set FQDN Custom Facts
+  set_fact:
+    www_hostname: "{{ ansible_hostname }}"
 
 - name: Replacing Apache Certificates
   ansible.builtin.copy:
@@ -9,7 +10,8 @@
     dest: /etc/pki/tls/certs
     owner: root
     group: root
-    backup: yes
+    backup: true
+    mode: '0600'
   with_items:
     - "{{ www_hostname }}.pem"
   loop: "{{ query('inventory_hostnames', 'apache') }}"
@@ -21,7 +23,8 @@
     dest: /etc/pki/tls/private
     owner: root
     group: root
-    backup: yes
+    backup: true
+    mode: '0600'
   with_items:
     - "{{ www_hostname }}.key"
   loop: "{{ query('inventory_hostnames', 'apache') }}"
@@ -34,7 +37,8 @@
     dest: /etc/pki/tls/certs
     owner: root
     group: root
-    backup: yes
+    backup: true
+    mode: '0600'
   with_items:
     - "{{ www_hostname }}.pem"
   loop: "{{ query('inventory_hostnames', 'nginx') }}"
@@ -46,7 +50,8 @@
     dest: /etc/pki/tls/certs
     owner: root
     group: root
-    backup: yes
+    backup: true
+    mode: '0600'
   with_items:
     - "{{ www_hostname }}.key"
   loop: "{{ query('inventory_hostnames', 'nginx') }}"

--- a/install/sslcerts.yml
+++ b/install/sslcerts.yml
@@ -4,7 +4,8 @@
 # for Apache and Nginx on EL systems
 #
 
-- hosts: all
+- name: Update Webserver SSL Certificates
+  hosts: all
   remote_user: root
   roles:
     - {role: sslcerts}


### PR DESCRIPTION
* Fix up lint warnings
* only use one CI linting run, no reason to run against three versions of python and `ansible-lint`