### PR TITLE
use ansible_nodename instead of ansible_fqdn.

### DIFF
--- a/install/roles/sslcerts/tasks/main.yml
+++ b/install/roles/sslcerts/tasks/main.yml
@@ -2,7 +2,7 @@
 # set fact for ansible_hostname
 - name: Set FQDN Custom Facts
   set_fact:
-    www_hostname: "{{ ansible_fqdn }}"
+    www_hostname: "{{ ansible_nodename }}"
 
 # Apache Webserver
 - name: Replacing Apache Certificates


### PR DESCRIPTION
* ansible_fqdn calls socket.getfqdn() in Python which isn't so dependable.